### PR TITLE
Refactor wbvalve device disconnection tests

### DIFF
--- a/system_tests/tests/wbvalve.py
+++ b/system_tests/tests/wbvalve.py
@@ -41,5 +41,8 @@ class WbvalveTests(unittest.TestCase):
 
     @skip_if_recsim("Can not test disconnection in rec sim")
     def test_GIVEN_device_not_connected_WHEN_get_status_THEN_alarm(self):
-        self._lewis.backdoor_set_on_device('connected', False)
-        self.ca.assert_that_pv_alarm_is('POS', ChannelAccess.Alarms.INVALID)
+        self.ca.assert_that_pv_alarm_is('POS', ChannelAccess.Alarms.NONE)
+        with self._lewis.backdoor_simulate_disconnected_device():
+            self.ca.assert_that_pv_alarm_is('POS', ChannelAccess.Alarms.INVALID)
+        # Assert alarms clear on reconnection
+        self.ca.assert_that_pv_alarm_is('POS', ChannelAccess.Alarms.NONE)


### PR DESCRIPTION
**Ticket: https://github.com/ISISComputingGroup/IBEX/issues/7266**
Refactoring all test modules which contain the common behaviour as described in the ticket.

- Used new emulator util function instead of old logic
- Added in asserts/before main assertions for robustness
- Occasionally fixed some tests which threw errors as a result of the above